### PR TITLE
Improve the data list in the README

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -11,27 +11,18 @@ This project contains China geospatial data that can be used in
 
 ## Data
 
-### China Administrative Divisions
-
-- [CN-border-La.gmt](CN-border-La.gmt): China's national borders, provincial borders,
-  ten-segment lines, and South China Sea island data
-- [CN-border-L1.gmt](CN-border-L1.gmt): China's national borders, ten-segment line,
-  and South China Sea island data, excluding provincial data
-- [ten-dash-line.gmt](ten-dash-line.gmt): ten-segment line data
-
-### Active tectonic blocks in the China mainland and neighboring regions
-
-- [CN-block-L1.gmt](CN-block-L1.gmt): Level-1 block boundary data
-- [CN-block-L1-deduced.gmt](CN-block-L1-deduced.gmt): Deduced Level-1 block boundary data
-- [CN-block-L2.gmt](CN-block-L2.gmt): Level-2 block boundary data
-
-### China Faults
-
-- [CN-faults.gmt](CN-faults.gmt): China faults
-
-### Geological Map of China and Adjacent Regions
-
-- [geo3al.gmt](geo3al.gmt): Geological map of China and adjacent regions
+- China Administrative Divisions
+  - [CN-border-La.gmt](CN-border-La.gmt): China's national borders, provincial borders,
+    ten-segment lines, and South China Sea island data
+  - [CN-border-L1.gmt](CN-border-L1.gmt): China's national borders, ten-segment line,
+    and South China Sea island data, excluding provincial data
+  - [ten-dash-line.gmt](ten-dash-line.gmt): ten-segment line data
+- Active tectonic blocks in the China mainland and neighboring regions
+  - [CN-block-L1.gmt](CN-block-L1.gmt): Level-1 block boundary data
+  - [CN-block-L1-deduced.gmt](CN-block-L1-deduced.gmt): Deduced Level-1 block boundary data
+  - [CN-block-L2.gmt](CN-block-L2.gmt): Level-2 block boundary data
+- China Faults:	[CN-faults.gmt](CN-faults.gmt)
+- Geological Map of China and Adjacent Regions: [geo3al.gmt](geo3al.gmt)
 
 ## Version history
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,16 @@
 
 ## 数据
 
-### 中国行政区划
-
-- [CN-border-La.gmt](CN-border-La.gmt): 中国国界、省界、十段线以及南海诸岛数据
-- [CN-border-L1.gmt](CN-border-L1.gmt): 中国国界、十段线以及南海诸岛数据，不含省界数据
-- [ten-dash-line.gmt](ten-dash-line.gmt): 仅包含十段线数据
-
-### 中国大陆及周边活动地块
-
-- [CN-block-L1.gmt](CN-block-L1.gmt): 一级地块边界数据
-- [CN-block-L1-deduced.gmt](CN-block-L1-deduced.gmt): 一级地块推断边界数据
-- [CN-block-L2.gmt](CN-block-L2.gmt): 二级地块边界数据
-
-### 中国断层
-
-- [CN-faults.gmt](CN-faults.gmt): 中国断层数据
-
-### 中国及邻区地质图
-
-- [geo3al.gmt](geo3al.gmt): 中国及邻区地质图
+- 中国行政区划
+  - [CN-border-La.gmt](CN-border-La.gmt): 中国国界、省界、十段线以及南海诸岛数据
+  - [CN-border-L1.gmt](CN-border-L1.gmt): 中国国界、十段线以及南海诸岛数据，不含省界数据
+  - [ten-dash-line.gmt](ten-dash-line.gmt): 仅包含十段线数据
+- 中国大陆及周边活动地块
+  - [CN-block-L1.gmt](CN-block-L1.gmt): 一级地块边界数据
+  - [CN-block-L1-deduced.gmt](CN-block-L1-deduced.gmt): 一级地块推断边界数据
+  - [CN-block-L2.gmt](CN-block-L2.gmt): 二级地块边界数据
+- 中国断层: [CN-faults.gmt](CN-faults.gmt)
+- 中国及邻区地质图: [geo3al.gmt](geo3al.gmt)
 
 ## 版本历史
 


### PR DESCRIPTION
感觉原来的数据列表在 github 上显示的时候占据了太多的垂直空间，而且对于单一文件的数据（例如 `geo3al.gmt`），一节只列一个文件显得很奇怪。

这个PR里使用了两级列表的方式解决这一问题。